### PR TITLE
Fix account use of utils

### DIFF
--- a/src/api/account/getAddresses.ts
+++ b/src/api/account/getAddresses.ts
@@ -1,7 +1,6 @@
 import fetch from 'cross-fetch';
-import { getHeaders } from '../utils';
 import { accountResponse, accountResponseType, Error } from '../../types';
-import { APIError } from '../../utils';
+import { APIError, getHeaders } from '../../utils';
 
 /**
  * Gets the HOPR and native addresses associated to the node.

--- a/src/api/account/getBalances.ts
+++ b/src/api/account/getBalances.ts
@@ -1,7 +1,6 @@
 import fetch from 'cross-fetch';
-import { getHeaders } from '../utils';
 import { accountResponse, accountResponseType, Error } from '../../types';
-import { APIError } from '../../utils';
+import { APIError, getHeaders } from '../../utils';
 
 /**
  * Fetches the HOPR and native balances of the node.

--- a/src/api/account/withdraw.ts
+++ b/src/api/account/withdraw.ts
@@ -1,7 +1,6 @@
 import fetch from 'cross-fetch';
-import { getHeaders } from '../utils';
 import { withdrawPayloadType, Error, withdrawResponse } from '../../types';
-import { APIError } from '../../utils';
+import { APIError, getHeaders } from '../../utils';
 
 /**
  * Withdraw the given currency amount to the specified recipient address.

--- a/src/api/utils/headers.ts
+++ b/src/api/utils/headers.ts
@@ -1,9 +1,0 @@
-import { Headers } from 'cross-fetch';
-
-export const getHeaders = (apiKey: string): Headers => {
-  const headers = new Headers();
-  headers.set('Content-Type', 'application/json');
-  headers.set('Accept-Content', 'application/json');
-  headers.set('x-auth-token', `${apiKey}`);
-  return headers;
-};

--- a/src/api/utils/index.ts
+++ b/src/api/utils/index.ts
@@ -1,1 +1,0 @@
-export * from './headers';

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -10,6 +10,6 @@ export const getHeaders = (apiKey: string): Headers => {
   const headers = new Headers();
   headers.set('Content-Type', 'application/json');
   headers.set('Accept-Content', 'application/json');
-  headers.set('x-auth-token', `${apiKey}`);
+  headers.set('x-auth-token', apiKey);
   return headers;
 };


### PR DESCRIPTION
### Overview

Remove `/api/utils` and use `/utils/` for the `get Headers` function.

### Why do this

At some point in development, the utils folder was duplicated inside `/api/` erroneously. This should not have happened since the `getHeaders` function was already in the general `utils` folder.

