### PR TITLE
refactor exports

### DIFF
--- a/src/api/account/index.ts
+++ b/src/api/account/index.ts
@@ -5,4 +5,3 @@ export * from './getBalances';
 export * from './getHoprAddress';
 export * from './getNativeBalance';
 export * from './withdraw';
-export * from './adapter';

--- a/src/api/adapter.ts
+++ b/src/api/adapter.ts
@@ -1,22 +1,29 @@
-import * as api from '.';
-
+import { AccountAdapter } from './account/adapter';
+import { AliasesAdapter } from './aliases/adapter';
+import { ChannelsAdapter } from './channels/adapter';
+import { NodeAdapter } from './node/adapter';
+import { PeerInfoAdapter } from './peerInfo/adapter';
+import { SettingsAdapter } from './settings/adapter';
+import { TicketsAdapter } from './tickets/adapter';
+import { TokensAdapter } from './tokens/adapter';
 export class ApiAdapter {
-  public account: api.AccountAdapter;
-  public aliases: api.AliasesAdapter;
-  public channels: api.ChannelsAdapter;
-  public node: api.NodeAdapter;
-  public peerInfo: api.PeerInfoAdapter;
-  public settings: api.SettingsAdapter;
-  public tickets: api.TicketsAdapter;
-  public tokens: api.TokensAdapter;
+  public account: AccountAdapter;
+  public aliases: AliasesAdapter;
+  public channels: ChannelsAdapter;
+  public node: NodeAdapter;
+  public peerInfo: PeerInfoAdapter;
+  public settings: SettingsAdapter;
+  public tickets: TicketsAdapter;
+  public tokens: TokensAdapter;
+
   constructor(private url: string, private apiKey: string) {
-    this.account = new api.AccountAdapter(this.url, this.apiKey);
-    this.aliases = new api.AliasesAdapter(this.url, this.apiKey);
-    this.channels = new api.ChannelsAdapter(this.url, this.apiKey);
-    this.node = new api.NodeAdapter(this.url, this.apiKey);
-    this.peerInfo = new api.PeerInfoAdapter(this.url, this.apiKey);
-    this.settings = new api.SettingsAdapter(this.url, this.apiKey);
-    this.tickets = new api.TicketsAdapter(this.url, this.apiKey);
-    this.tokens = new api.TokensAdapter(this.url, this.apiKey);
+    this.account = new AccountAdapter(this.url, this.apiKey);
+    this.aliases = new AliasesAdapter(this.url, this.apiKey);
+    this.channels = new ChannelsAdapter(this.url, this.apiKey);
+    this.node = new NodeAdapter(this.url, this.apiKey);
+    this.peerInfo = new PeerInfoAdapter(this.url, this.apiKey);
+    this.settings = new SettingsAdapter(this.url, this.apiKey);
+    this.tickets = new TicketsAdapter(this.url, this.apiKey);
+    this.tokens = new TokensAdapter(this.url, this.apiKey);
   }
 }

--- a/src/api/aliases/index.ts
+++ b/src/api/aliases/index.ts
@@ -2,4 +2,3 @@ export * from './getAlias';
 export * from './getAliases';
 export * from './setAlias';
 export * from './removeAlias';
-export * from './adapter';

--- a/src/api/channels/index.ts
+++ b/src/api/channels/index.ts
@@ -5,4 +5,3 @@ export * from './getChannels';
 export * from './getChannelTickets';
 export * from './openChannels';
 export * from './redeemChannelTickets';
-export * from './adapter';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,4 +7,3 @@ export * from './node';
 export * from './peerInfo';
 export * from './tickets';
 export * from './settings';
-export * from './adapter';

--- a/src/api/messages/index.ts
+++ b/src/api/messages/index.ts
@@ -1,4 +1,3 @@
 export * from './sendMessage';
 export * from './sign';
 export * from './websocket';
-export * from './adapter';

--- a/src/api/node/index.ts
+++ b/src/api/node/index.ts
@@ -4,4 +4,3 @@ export * from './getMetrics';
 export * from './getPeers';
 export * from './getVersion';
 export * from './pingNode';
-export * from './adapter';

--- a/src/api/peerInfo/index.ts
+++ b/src/api/peerInfo/index.ts
@@ -1,2 +1,1 @@
 export * from './getPeerInfo';
-export * from './adapter';

--- a/src/api/settings/index.ts
+++ b/src/api/settings/index.ts
@@ -1,3 +1,2 @@
 export * from './getSettings';
 export * from './setSetting';
-export * from './adapter';

--- a/src/api/tickets/index.ts
+++ b/src/api/tickets/index.ts
@@ -1,4 +1,3 @@
 export * from './getStatistics';
 export * from './getTickets';
 export * from './redeemTickets';
-export * from './adapter';

--- a/src/api/tokens/index.ts
+++ b/src/api/tokens/index.ts
@@ -1,4 +1,3 @@
 export * from './createToken';
 export * from './deleteToken';
 export * from './getToken';
-export * from './adapter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export * from './sdk';
-export * from './api';
+export * as api from './api';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,7 +1,7 @@
-import { ApiAdapter } from './api';
-export class SDK {
+import { ApiAdapter } from './api/adapter';
+export class HoprSdk {
   public api: ApiAdapter;
-  constructor(private url: string, private apiToken: string) {
-    this.api = new ApiAdapter(this.url, this.apiToken);
+  constructor({ url, apiToken }: { url: string; apiToken: string }) {
+    this.api = new ApiAdapter(url, apiToken);
   }
 }


### PR DESCRIPTION
### Problem
When importing 'hopr-sdk' it would show a lot of named exports and it was generally confusing on how to use it. Also it exported adapters that are not meant to be used at such a low level.

#### Changes
- no longer exporting adapters
- rename SDK to HoprSdk so it is easier to understand when importing
- all pure api functions can now be found in `api` variable

#### examples

##### sdk class
before
```
import { SDK } from 'hopr-sdk'

const sdk = new SDK({...})
```
after
```
import { HoprSdk } from 'hopr-sdk'

const sdk = new HoprSdk({...})
```

##### api functions
before
```
import {getInfo } from 'hopr-sdk'

const info = getInfo({})
```

after
```
import {api } from 'hopr-sdk'

const info = api.getInfo({})
```