### PR TITLE
rename openChannels to openChannel

### DIFF
--- a/src/api/channels/adapter.ts
+++ b/src/api/channels/adapter.ts
@@ -2,7 +2,7 @@ import {
   CloseChannelPayloadType,
   FundChannelsPayloadType,
   GetChannelPayloadType,
-  OpenChannelsPayloadType,
+  OpenChannelPayloadType,
   PeerIdPayloadType,
   RemoveBasicAuthenticationPayloadType
 } from '../../types';
@@ -12,7 +12,7 @@ import { fundChannels } from './fundChannels';
 import { getChannel } from './getChannel';
 import { getChannelTickets } from './getChannelTickets';
 import { getChannels } from './getChannels';
-import { openChannels } from './openChannels';
+import { openChannel } from './openChannel';
 import { redeemChannelTickets } from './redeemChannelTickets';
 
 const log = createLogger('channels');
@@ -94,11 +94,11 @@ export class ChannelsAdapter {
     }
   }
 
-  public async openChannels(
-    payload: RemoveBasicAuthenticationPayloadType<OpenChannelsPayloadType>
+  public async openChannel(
+    payload: RemoveBasicAuthenticationPayloadType<OpenChannelPayloadType>
   ) {
     try {
-      return await openChannels({
+      return await openChannel({
         apiKey: this.apiKey,
         url: this.url,
         amount: payload.amount,

--- a/src/api/channels/index.ts
+++ b/src/api/channels/index.ts
@@ -3,5 +3,5 @@ export * from './fundChannels';
 export * from './getChannel';
 export * from './getChannels';
 export * from './getChannelTickets';
-export * from './openChannels';
+export * from './openChannel';
 export * from './redeemChannelTickets';

--- a/src/api/channels/openChannel.spec.ts
+++ b/src/api/channels/openChannel.spec.ts
@@ -1,11 +1,11 @@
 import nock from 'nock';
 import { APIError } from '../../utils';
-import { openChannels } from './openChannels';
+import { openChannel } from './openChannel';
 
 const API_URL = 'http://localhost:3001';
 const API_KEY = 'S3CR3T-T0K3N';
 
-describe('test openChannels', function () {
+describe('test openChannel', function () {
   beforeEach(function () {
     nock.cleanAll();
   });
@@ -17,7 +17,7 @@ describe('test openChannels', function () {
         '0x37954ca4a630aa28f045df2e8e604cae22071046042e557355acf00f4ef20d2e'
     });
 
-    const response = await openChannels({
+    const response = await openChannel({
       apiKey: API_KEY,
       url: API_URL,
       peerId: '16Uiu2HAmUsJwbECMroQUC29LQZZWsYpYZx1oaM1H9DBoZHLkYn12',
@@ -37,7 +37,7 @@ describe('test openChannels', function () {
     });
 
     await expect(
-      openChannels({
+      openChannel({
         apiKey: API_KEY,
         url: API_URL,
         peerId: '16Uiu2HAmUsJwbECMroQUC29LQZZWsYpYZx1oaM1H9DBoZHLkYn12',
@@ -52,7 +52,7 @@ describe('test openChannels', function () {
     });
 
     await expect(
-      openChannels({
+      openChannel({
         apiKey: API_KEY,
         url: API_URL,
         peerId: '16Uiu2HAmUsJwbECMroQUC29LQZZWsYpYZx1oaM1H9DBoZHLkYn12',
@@ -66,7 +66,7 @@ describe('test openChannels', function () {
     });
 
     await expect(
-      openChannels({
+      openChannel({
         apiKey: API_KEY,
         url: API_URL,
         peerId: '16Uiu2HAmUsJwbECMroQUC29LQZZWsYpYZx1oaM1H9DBoZHLkYn12',
@@ -80,7 +80,7 @@ describe('test openChannels', function () {
     });
 
     await expect(
-      openChannels({
+      openChannel({
         apiKey: API_KEY,
         url: API_URL,
         peerId: '16Uiu2HAmUsJwbECMroQUC29LQZZWsYpYZx1oaM1H9DBoZHLkYn12',
@@ -94,7 +94,7 @@ describe('test openChannels', function () {
       error: 'Full error message.'
     });
     await expect(
-      openChannels({
+      openChannel({
         apiKey: API_KEY,
         url: API_URL,
         peerId: '16Uiu2HAmUsJwbECMroQUC29LQZZWsYpYZx1oaM1H9DBoZHLkYn12',

--- a/src/api/channels/openChannel.ts
+++ b/src/api/channels/openChannel.ts
@@ -1,17 +1,17 @@
 import fetch from 'cross-fetch';
 import {
   Error,
-  OpenChannelsResponse,
-  OpenChannelsResponseType,
-  type OpenChannelsPayloadType,
+  OpenChannelResponse,
+  OpenChannelResponseType,
+  type OpenChannelPayloadType,
   RemoveBasicAuthenticationPayloadType
 } from '../../types';
 import { APIError, getHeaders } from '../../utils';
 
-export const openChannels = async (
-  payload: OpenChannelsPayloadType
-): Promise<OpenChannelsResponseType> => {
-  const body: RemoveBasicAuthenticationPayloadType<OpenChannelsPayloadType> = {
+export const openChannel = async (
+  payload: OpenChannelPayloadType
+): Promise<OpenChannelResponseType> => {
+  const body: RemoveBasicAuthenticationPayloadType<OpenChannelPayloadType> = {
     amount: payload.amount,
     peerId: payload.peerId
   };
@@ -24,7 +24,7 @@ export const openChannels = async (
 
   const jsonResponse = await rawResponse.json();
 
-  const parsedRes = OpenChannelsResponse.safeParse(jsonResponse);
+  const parsedRes = OpenChannelResponse.safeParse(jsonResponse);
 
   if (parsedRes.success) {
     return parsedRes.data;

--- a/src/types/channels.ts
+++ b/src/types/channels.ts
@@ -31,19 +31,19 @@ export type FundChannelsResponseType = ZodToType<typeof FundChannelsResponse>;
 
 /** Open channel */
 
-export const OpenChannelsPayload = BasicAuthenticationPayload.extend({
+export const OpenChannelPayload = BasicAuthenticationPayload.extend({
   peerId: z.string(),
   amount: z.string()
 });
 
-export type OpenChannelsPayloadType = ZodToType<typeof OpenChannelsPayload>;
+export type OpenChannelPayloadType = ZodToType<typeof OpenChannelPayload>;
 
-export const OpenChannelsResponse = z.object({
+export const OpenChannelResponse = z.object({
   channelId: z.string(),
   receipt: z.string()
 });
 
-export type OpenChannelsResponseType = ZodToType<typeof OpenChannelsResponse>;
+export type OpenChannelResponseType = ZodToType<typeof OpenChannelResponse>;
 
 /** Get channels */
 


### PR DESCRIPTION
### why ?
`openChannels` function actually only opens one channel, so it does not make sense for it to be plural