### PR TITLE
update package json to include types in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.0.1-alpha.0",
   "license": "GPL-3.0",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./types": "./dist/types/index.js",
     "./api": "./dist/api/index.js",
     "./utils": "./dist/utils/index.js"


### PR DESCRIPTION
### Why? 
I ran `npx publint` to see what this package could be lacking before we export and received the warning:
```
pkg.exports["."] has types at ./dist/index.d.ts but it is not exported from pkg.exports. Consider adding it to pkg.exports["."].types to be compatible with TypeScript's "moduleResolution": "bundler" compiler option.
```

After this change everything is ok for publint.

[more info on what is publint](https://github.com/bluwy/publint)