### PR TITLE
Fixed Module Resolution by Adding "require" to Package Exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
     "./types": "./dist/types/index.js",
     "./api": "./dist/api/index.js",


### PR DESCRIPTION
closes #59 

### Overview
This PR addresses an issue with our Node.js package where the Node.js module resolution algorithm was unable to find a suitable file to load for our package, resulting in a "No exports main defined in package.json" error.

In our package.json, we used the "exports" field to control the exported modules for our package and structure our module. This is a newer feature introduced in Node.js 12 and offers greater control to package authors. However, Node.js was unable to locate the main file specified in our "exports" field, leading to the observed error.

The problem was resolved by specifying the "default" export in our "exports" field, which provides a path for both import and require operations.

The updated "exports" field looks like this:

```json
"exports": {
    ".": {
      "types": "./dist/index.d.ts",
      "import": "./dist/index.js",
      "require": "./dist/index.js"
    },
    "./types": "./dist/types/index.js",
    "./api": "./dist/api/index.js",
    "./utils": "./dist/utils/index.js"
}
```
With this configuration, Node.js uses ./dist/index.js as the main module for both import and require.

This adjustment ensures our package can be correctly loaded and used in a Node.js environment. Our users can now use the SDK without encountering module resolution errors.