### PR TITLE
fix debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/debug": "^4.1.7",
     "@types/jest": "^29.5.1",
     "@types/ws": "^8.5.4",
-    "debug": "^4.3.4",
     "jest": "^29.5.0",
     "nock": "^13.3.1",
     "prettier": "^2.8.8",
@@ -62,7 +61,8 @@
     "isomorphic-ws": "^5.0.0",
     "rlp": "^3.0.0",
     "ws": "^8.13.0",
-    "zod": "^3.21.4"
+    "zod": "^3.21.4",
+    "debug": "^4.3.4"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### overview
since `debug` was a dev dependency it was not part of the actual library installed by other projects. When trying to debug it would through an error.