### PR TITLE
Remove unnecessary test case in sendMessage.spec.ts

### DIFF
--- a/src/api/messages/sendMessages.spec.ts
+++ b/src/api/messages/sendMessages.spec.ts
@@ -54,17 +54,6 @@ describe('sendMessage', () => {
     expect(response).toBe('challenge-token');
   });
 
-  it('should throw an error if no PATH or hops provided', async () => {
-    await expect(
-      sendMessage({
-        apiToken: API_TOKEN,
-        apiEndpoint: API_ENDPOINT,
-        body: BODY,
-        recipient: RECIPIENT
-      })
-    ).rejects.toThrow('No path or number of hops provided.');
-  });
-
   it('should return 401 if authentication failed', async () => {
     const errorResponse = {
       status: 'authentication failed',


### PR DESCRIPTION
Remove test for:
```ts
if (!payload.path && !payload.hops)
  throw new Error('No path or number of hops provided.');
```
Which was removed on the previous PR