### PR TITLE
Add fix to the docs auto generation

### DIFF
--- a/.github/scripts/commit-and-push-all-changes.sh
+++ b/.github/scripts/commit-and-push-all-changes.sh
@@ -14,14 +14,13 @@ test -z "${HOPR_GITHUB_REF:-}" && (
 )
 
 # Check if there are changes in the docs/ directory from docs generated steps before
-if [ -n "$(git diff --name-only -- docs/)" ]; then
-    git add docs/*
-    git commit -m "${HOPR_GIT_MSG}"
+if [ -n "$(git diff --name-only origin/docs -- docs/)" ]; then
+    git add --all docs/
+    git commit -m "${HOPR_GIT_MSG}"å
 
     # must get the latest version of the branch from origin before pushing
     git pull origin docs --rebase --strategy-option recursive -X ours # NB! when pull rebasing, ours is the incoming change (see https://stackoverflow.com/a/3443225)
-
-    git push origin docs # Push changes to the 'docs' branch
+    git push origin HEAD:refs/heads/docs                              # Push changes to the 'docs' branch
 else
     echo "No changes found in the docs/ directory. Skipping commit and push."
 fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Fetch docs branch
+        run: git fetch origin docs:refs/remotes/origin/docs
+
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Fixes #66

### Overview

In this pull request, we fixed the issue related to the docs being auto generated but not commited to the `docs` branch.

The changes done where fetching the docs branch before running the scripts, this with the intent to compare the locally generated docs with the docs from the `docs` branch (done this way):
`git diff --name-only origin/docs -- docs/`

if there are differences, we then will add everything including the dotfiles generated to a commit, we rebase our branch with the commits from the docs branch and finally we push to `HEAD:refs/heads/docs`.

this was tested on a different private repo with success.