### PR TITLE
Fix README to point to docs on `docs` branch

### DIFF
--- a/.github/scripts/commit-and-push-all-changes.sh
+++ b/.github/scripts/commit-and-push-all-changes.sh
@@ -17,11 +17,10 @@ test -z "${HOPR_GITHUB_REF:-}" && (
 if [ -n "$(git diff --name-only origin/docs -- docs/)" ]; then
     git add --all docs/
     git commit -m "${HOPR_GIT_MSG}"
-    git log --name-status HEAD^..HEAD
 
-    # # must get the latest version of the branch from origin before pushing
-    # git pull origin docs --rebase --strategy-option recursive -X ours # NB! when pull rebasing, ours is the incoming change (see https://stackoverflow.com/a/3443225)
-    # git push origin HEAD:refs/heads/docs                              # Push changes to the 'docs' branch
+    # must get the latest version of the branch from origin before pushing
+    git pull origin docs --rebase --strategy-option recursive -X ours # NB! when pull rebasing, ours is the incoming change (see https://stackoverflow.com/a/3443225)
+    git push origin HEAD:refs/heads/docs                              # Push changes to the 'docs' branch
 else
     echo "No changes found in the docs/ directory. Skipping commit and push."
 fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,6 @@ on:
     branches: [main]
     paths-ignore:
       - "docs/**"
-  pull_request:
-    types: [opened, synchronize]
 
 concurrency:
   # group runs by <name of the workflow>-<name of job>-<branch name>


### PR DESCRIPTION
### Overview

This pull request fixes the issue of the README pointing to non-existing files on the main branch. The README now will point to the auto generated (hence always up-to-date) docs on the `docs` branch.