### PR TITLE
add custom timeout to all class functions

### DIFF
--- a/src/api/account/adapter.ts
+++ b/src/api/account/adapter.ts
@@ -1,4 +1,5 @@
 import {
+  BasePayloadType,
   RemoveBasicAuthenticationPayloadType,
   WithdrawPayloadType
 } from '../../types';
@@ -44,11 +45,13 @@ export class AccountAdapter {
    * Gets the HOPR and native addresses associated to the node.
    * @returns — A promise that resolves with an object containing the HOPR and native addresses.
    */
-  public async getAddresses() {
+  public async getAddresses(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getAddresses({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -56,11 +59,13 @@ export class AccountAdapter {
    * Fetches the HOPR and native balances of the node.
    * @returns — A Promise that resolves with an object containing the HOPR and native balances.
    */
-  public async getBalances() {
+  public async getBalances(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getBalances({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -68,11 +73,13 @@ export class AccountAdapter {
    * Gets the HOPR address associated to the node.
    * @returns — A Promise that resolves to the HOPR address.
    */
-  public async getHoprAddress() {
+  public async getHoprAddress(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getHoprAddress({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -80,11 +87,13 @@ export class AccountAdapter {
    * Gets the HOPR balance associated to the node.
    * @returns — A Promise that resolves to a string representing the HOPR balance.
    */
-  public async getHoprBalance() {
+  public async getHoprBalance(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getHoprBalance({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -92,11 +101,13 @@ export class AccountAdapter {
    * Gets the native blockchain address associated to the node.
    * @returns — A Promise that resolves to the native address.
    */
-  public async getNativeAddress() {
+  public async getNativeAddress(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getNativeAddress({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -104,11 +115,13 @@ export class AccountAdapter {
    * Gets the native blockchain balance associated to the node.
    * @returns — A Promise that resolves with a string representing the native balance.
    */
-  public async getNativeBalance() {
+  public async getNativeBalance(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getNativeBalance({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
   /**

--- a/src/api/aliases/adapter.ts
+++ b/src/api/aliases/adapter.ts
@@ -1,5 +1,6 @@
 import {
   AliasPayloadType,
+  BasePayloadType,
   RemoveBasicAuthenticationPayloadType,
   SetAliasPayloadType
 } from '../../types';
@@ -43,11 +44,13 @@ export class AliasesAdapter {
    *
    * @returns An object with alias names as keys and the peerId associated with the alias.
    */
-  public async getAliases(): Promise<Record<string, string> | undefined> {
+  public async getAliases(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ): Promise<Record<string, string> | undefined> {
     return getAliases({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -65,7 +68,7 @@ export class AliasesAdapter {
     return setAlias({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       alias: payload.alias,
       peerId: payload.peerId
     });
@@ -83,7 +86,7 @@ export class AliasesAdapter {
     return getAlias({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       alias: payload.alias
     });
   }
@@ -100,7 +103,7 @@ export class AliasesAdapter {
     return removeAlias({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       alias: payload.alias
     });
   }

--- a/src/api/channels/adapter.ts
+++ b/src/api/channels/adapter.ts
@@ -1,4 +1,5 @@
 import {
+  BasePayloadType,
   CloseChannelPayloadType,
   FundChannelsPayloadType,
   GetChannelPayloadType,
@@ -54,8 +55,7 @@ export class ChannelsAdapter {
       apiToken: this.apiToken,
       apiEndpoint: this.apiEndpoint,
       timeout: this.timeout,
-      direction: payload.direction,
-      peerId: payload.peerId
+      ...payload
     });
   }
 
@@ -66,25 +66,27 @@ export class ChannelsAdapter {
       apiToken: this.apiToken,
       apiEndpoint: this.apiEndpoint,
       timeout: this.timeout,
-      incomingAmount: payload.incomingAmount,
-      outgoingAmount: payload.outgoingAmount,
-      peerId: payload.peerId
+      ...payload
     });
   }
 
-  public async getChannels() {
+  public async getChannels(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getChannels({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
-  public async getChannelsWithFullTopology() {
+  public async getChannelsWithFullTopology(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getChannelsWithFullTopology({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -94,7 +96,7 @@ export class ChannelsAdapter {
     return getChannel({
       apiToken: this.apiToken,
       apiEndpoint: this.apiEndpoint,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       direction: payload.direction,
       peerId: payload.peerId
     });
@@ -110,7 +112,7 @@ export class ChannelsAdapter {
     return openChannel({
       apiToken: this.apiToken,
       apiEndpoint: this.apiEndpoint,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       amount: payload.amount,
       peerId: payload.peerId
     });
@@ -122,7 +124,7 @@ export class ChannelsAdapter {
     return getChannelTickets({
       apiToken: this.apiToken,
       apiEndpoint: this.apiEndpoint,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       peerId: payload.peerId
     });
   }
@@ -137,7 +139,7 @@ export class ChannelsAdapter {
     return redeemChannelTickets({
       apiToken: this.apiToken,
       apiEndpoint: this.apiEndpoint,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       peerId: payload.peerId
     });
   }

--- a/src/api/messages/adapter.ts
+++ b/src/api/messages/adapter.ts
@@ -41,7 +41,7 @@ export class MessagesAdapter {
     return sendMessage({
       apiToken: this.apiToken,
       apiEndpoint: this.apiEndpoint,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       body: payload.body,
       recipient: payload.recipient,
       hops: payload.hops,
@@ -55,7 +55,7 @@ export class MessagesAdapter {
     return sign({
       apiToken: this.apiToken,
       apiEndpoint: this.apiEndpoint,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       message: payload.message
     });
   }

--- a/src/api/node/adapter.ts
+++ b/src/api/node/adapter.ts
@@ -1,4 +1,5 @@
 import {
+  BasePayloadType,
   GetPeersPayloadType,
   PingNodePayloadType,
   RemoveBasicAuthenticationPayloadType
@@ -38,27 +39,33 @@ export class NodeAdapter {
     this.timeout = timeout;
   }
 
-  public async getEntryNodes() {
+  public async getEntryNodes(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getEntryNodes({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
-  public async getInfo() {
+  public async getInfo(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getInfo({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
-  public async getMetrics() {
+  public async getMetrics(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getMetrics({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -68,16 +75,18 @@ export class NodeAdapter {
     return getPeers({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       quality: payload.quality
     });
   }
 
-  public async getVersion() {
+  public async getVersion(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getVersion({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -87,7 +96,7 @@ export class NodeAdapter {
     return pingNode({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       peerId: payload.peerId
     });
   }

--- a/src/api/peerInfo/adapter.ts
+++ b/src/api/peerInfo/adapter.ts
@@ -38,7 +38,7 @@ export class PeerInfoAdapter {
     return getPeerInfo({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       peerId: payload.peerId
     });
   }

--- a/src/api/settings/adapter.ts
+++ b/src/api/settings/adapter.ts
@@ -1,4 +1,5 @@
 import {
+  BasePayloadType,
   RemoveBasicAuthenticationPayloadType,
   SetSettingPayloadType
 } from '../../types';
@@ -33,11 +34,13 @@ export class SettingsAdapter {
     this.timeout = timeout;
   }
 
-  public async getSettings() {
+  public async getSettings(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getSettings({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -47,7 +50,7 @@ export class SettingsAdapter {
     return setSetting({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       setting: payload.setting,
       settingValue: payload.settingValue
     });

--- a/src/api/tickets/adapter.ts
+++ b/src/api/tickets/adapter.ts
@@ -1,3 +1,7 @@
+import {
+  BasePayloadType,
+  RemoveBasicAuthenticationPayloadType
+} from '../../types';
 import { createLogger } from '../../utils';
 import { getStatistics } from './getStatistics';
 import { getTickets } from './getTickets';
@@ -30,19 +34,23 @@ export class TicketsAdapter {
     this.timeout = timeout;
   }
 
-  public async getStatistics() {
+  public async getStatistics(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getStatistics({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
-  public async getTickets() {
+  public async getTickets(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getTickets({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 
@@ -50,11 +58,13 @@ export class TicketsAdapter {
    * Redeems all the unredeemed HOPR tickets owned by the HOPR node.
    * This operation may take more than 5 minutes to complete as it involves on-chain operations.
    */
-  public async redeemTickets() {
+  public async redeemTickets(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return redeemTickets({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 }

--- a/src/api/tokens/adapter.ts
+++ b/src/api/tokens/adapter.ts
@@ -1,4 +1,5 @@
 import {
+  BasePayloadType,
   CreateTokenPayloadType,
   DeleteTokenPayloadType,
   RemoveBasicAuthenticationPayloadType
@@ -55,7 +56,7 @@ export class TokensAdapter {
     return createToken({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       capabilities: payload.capabilities,
       description: payload.description,
       lifetime: payload.lifetime
@@ -75,7 +76,7 @@ export class TokensAdapter {
     return deleteToken({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout,
+      timeout: payload.timeout ?? this.timeout,
       id: payload.id
     });
   }
@@ -85,11 +86,13 @@ export class TokensAdapter {
    *
    * @returns A Promise that resolves to an object with the token info.
    */
-  public async getToken() {
+  public async getToken(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return getToken({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 }

--- a/src/flows/adapter.ts
+++ b/src/flows/adapter.ts
@@ -1,4 +1,7 @@
-import { RemoveBasicAuthenticationPayloadType } from '../types';
+import {
+  BasePayloadType,
+  RemoveBasicAuthenticationPayloadType
+} from '../types';
 import { openMultipleChannels } from './openMultipleChannels';
 import { cashOut } from './cashOut';
 import { safeSendMessage } from './safeSendMessage';
@@ -134,11 +137,13 @@ export class FlowsAdapter {
    *          or `undefined` if no receipt is available.
    *   - `redeemedTickets`: A boolean value indicating whether the tickets were redeemed successfully.
    */
-  public async closeEverything() {
+  public async closeEverything(
+    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+  ) {
     return closeEverything({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: this.timeout
+      timeout: payload.timeout ?? this.timeout
     });
   }
 }

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -30,4 +30,4 @@ export type BasePayloadType = z.infer<typeof BasePayload>;
  * @typeparam T - The payload type from which to remove the properties.
  */
 export type RemoveBasicAuthenticationPayloadType<T extends BasePayloadType> =
-  Pick<T, Exclude<keyof T, 'apiEndpoint' | 'apiToken' | 'timeout'>>;
+  Pick<T, Exclude<keyof T, 'apiEndpoint' | 'apiToken'>>;


### PR DESCRIPTION
### overview
Adds a custom timeout to all class functions

#### why?
We thought about creating adapters for users to not have to state apiEndpoint and apiToken for every function call however we are currently limiting them to one timeout throughout all api calls which in reality is a bit constraining. 

This is a feature request from @nionis