### PR TITLE
add tests for class timeouts

### DIFF
--- a/src/sdk.spec.ts
+++ b/src/sdk.spec.ts
@@ -2,13 +2,7 @@ import nock from 'nock';
 import { HoprSDK } from './sdk';
 
 describe('test sdk class', function () {
-  afterEach(function () {
-    jest.clearAllMocks();
-    nock.abortPendingRequests();
-    nock.cleanAll();
-  });
-
-  it('should abort the request with custom timeout', async function () {
+  it('should be able to overwrite timeout', async function () {
     const apiEndpoint = new URL('https://example.com');
     const apiToken = 'token';
     // request delay
@@ -28,32 +22,6 @@ describe('test sdk class', function () {
         recipient: 'recipient',
         path: [],
         timeout: 500
-      })
-    ).rejects.toThrowError('TIMEOUT');
-  });
-  it('should abort the request if request takes longer than class timeout', async function () {
-    const apiEndpoint = new URL('https://example.com');
-    const apiToken = 'token';
-    // request delay
-    const delay = 20000;
-    // class timeout 500s
-    const sdk = new HoprSDK({
-      apiEndpoint: apiEndpoint.origin,
-      apiToken,
-      timeout: 500
-    });
-
-    nock(apiEndpoint.origin)
-      .post('/api/v2/messages')
-      .delay(delay) // Delay the response to trigger a timeout
-      .reply(200, 'Mock data');
-
-    // delay > timeout so it should throw error
-    await expect(
-      sdk.api.messages.sendMessage({
-        body: 'test',
-        recipient: 'recipient',
-        path: []
       })
     ).rejects.toThrowError('TIMEOUT');
   });

--- a/src/sdk.spec.ts
+++ b/src/sdk.spec.ts
@@ -1,0 +1,60 @@
+import nock from 'nock';
+import { HoprSDK } from './sdk';
+
+describe('test sdk class', function () {
+  afterEach(function () {
+    jest.clearAllMocks();
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
+  it('should abort the request with custom timeout', async function () {
+    const apiEndpoint = new URL('https://example.com');
+    const apiToken = 'token';
+    // request delay
+    const delay = 20000;
+    // has default timeout of 30s
+    const sdk = new HoprSDK({ apiEndpoint: apiEndpoint.origin, apiToken });
+
+    nock(apiEndpoint.origin)
+      .post('/api/v2/messages')
+      .delay(delay) // Delay the response to trigger a timeout
+      .reply(200, 'Mock data');
+
+    // delay > timeout so it should throw error
+    await expect(
+      sdk.api.messages.sendMessage({
+        body: 'test',
+        recipient: 'recipient',
+        path: [],
+        timeout: 500
+      })
+    ).rejects.toThrowError('TIMEOUT');
+  });
+  it('should abort the request if request takes longer than class timeout', async function () {
+    const apiEndpoint = new URL('https://example.com');
+    const apiToken = 'token';
+    // request delay
+    const delay = 20000;
+    // class timeout 500s
+    const sdk = new HoprSDK({
+      apiEndpoint: apiEndpoint.origin,
+      apiToken,
+      timeout: 500
+    });
+
+    nock(apiEndpoint.origin)
+      .post('/api/v2/messages')
+      .delay(delay) // Delay the response to trigger a timeout
+      .reply(200, 'Mock data');
+
+    // delay > timeout so it should throw error
+    await expect(
+      sdk.api.messages.sendMessage({
+        body: 'test',
+        recipient: 'recipient',
+        path: []
+      })
+    ).rejects.toThrowError('TIMEOUT');
+  });
+});

--- a/src/utils/fetchWithTimeout.spec.ts
+++ b/src/utils/fetchWithTimeout.spec.ts
@@ -1,37 +1,46 @@
 import { fetchWithTimeout } from './fetchWithTimeout';
-import nock from 'nock';
+import http from 'http';
+
+const PORT = 5555;
+const API_ENDPOINT = new URL(`http://localhost:${PORT}`);
 
 describe('fetchWithTimeout', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    nock.cleanAll();
+  let httpServer: http.Server;
+
+  afterEach((done) => {
+    if (httpServer) httpServer.close(done);
   });
 
-  it('should abort the request if it takes longer than the specified timeout', async () => {
-    const apiEndpoint = new URL('https://example.com');
+  it('should abort the request if it takes longer than the specified timeout', async function () {
+    const apiEndpoint = new URL(API_ENDPOINT);
     const options = { method: 'GET' };
     const ms = 1000;
 
-    nock(apiEndpoint.origin)
-      .get(apiEndpoint.pathname)
-      .delay(ms + 100) // Delay the response to trigger a timeout
-      .reply(200, 'Mock data');
+    httpServer = http.createServer((req, res) => {
+      setTimeout(() => {
+        res.end(JSON.stringify({ key: 'value' }));
+      }, ms); // delay the response
+    });
+
+    httpServer.listen(PORT);
 
     await expect(
       fetchWithTimeout(apiEndpoint, options, ms)
     ).rejects.toThrowError('TIMEOUT');
   });
 
-  it('should return the response when the request completes within the timeout', async () => {
+  it('should return the response when the request completes within the timeout', async function () {
     const mockResponse = { status: 200, data: 'Mock data' };
 
-    const apiEndpoint = new URL('https://example.com');
-    const options = { method: 'POST' };
+    const apiEndpoint = new URL(API_ENDPOINT);
+    const options = { method: 'GET' };
     const ms = 1000;
 
-    nock(apiEndpoint.origin)
-      .post(apiEndpoint.pathname)
-      .reply(200, mockResponse);
+    httpServer = http.createServer((req, res) => {
+      res.end(JSON.stringify(mockResponse));
+    });
+
+    httpServer.listen(PORT);
 
     const response = await fetchWithTimeout(apiEndpoint, options, ms);
     const jsonResponse = await response.json();

--- a/src/utils/fetchWithTimeout.spec.ts
+++ b/src/utils/fetchWithTimeout.spec.ts
@@ -14,7 +14,7 @@ describe('fetchWithTimeout', () => {
   it('should abort the request if it takes longer than the specified timeout', async function () {
     const apiEndpoint = new URL(API_ENDPOINT);
     const options = { method: 'GET' };
-    const ms = 1000;
+    const ms = 200;
 
     httpServer = http.createServer((req, res) => {
       setTimeout(() => {
@@ -34,16 +34,85 @@ describe('fetchWithTimeout', () => {
 
     const apiEndpoint = new URL(API_ENDPOINT);
     const options = { method: 'GET' };
-    const ms = 1000;
+    const ms = 200;
 
     httpServer = http.createServer((req, res) => {
-      res.end(JSON.stringify(mockResponse));
+      setTimeout(() => {
+        res.end(JSON.stringify(mockResponse));
+      }, ms); // delay the response
     });
 
     httpServer.listen(PORT);
 
-    const response = await fetchWithTimeout(apiEndpoint, options, ms);
+    const response = await fetchWithTimeout(apiEndpoint, options, ms * 2);
     const jsonResponse = await response.json();
     expect(jsonResponse).toEqual(mockResponse);
+  });
+
+  it('should be able to send multiple requests at the same time', async function () {
+    const mockResponse = { status: 200, data: 'Mock data' };
+
+    const apiEndpoint = new URL(API_ENDPOINT);
+    const options = { method: 'GET' };
+    const ms = 200;
+    const requests = Array.from({ length: 5 });
+
+    httpServer = http.createServer((req, res) => {
+      setTimeout(() => {
+        res.end(JSON.stringify(mockResponse));
+      }, ms); // delay the response
+    });
+
+    httpServer.listen(PORT);
+
+    const responses = [];
+
+    for (const request of requests) {
+      const temp = await fetchWithTimeout(apiEndpoint, options, ms * 2);
+      responses.push(temp);
+    }
+
+    // get back 5 responses for 5 requests
+    expect(responses.length).toEqual(requests.length);
+  });
+
+  it('should throw error if one requests fails while trying to send multiple requests at the same time', async function () {
+    const mockResponse = { status: 200, data: 'Mock data' };
+
+    const apiEndpoint = new URL(API_ENDPOINT);
+    const options = { method: 'GET' };
+    const ms = 200;
+    const requests = Array.from({ length: 5 }).map((value, index) => index);
+
+    httpServer = http.createServer((req, res) => {
+      setTimeout(() => {
+        res.end(JSON.stringify(mockResponse));
+      }, ms); // delay the response
+    });
+
+    httpServer.listen(PORT);
+
+    const responses = [];
+    const errors = [];
+    for (const request of requests) {
+      try {
+        // make one request fail by decreasing ms
+        const temp = await fetchWithTimeout(
+          apiEndpoint,
+          options,
+          request !== 3 ? ms * 2 : ms / 2
+        );
+        responses.push(temp);
+      } catch (e) {
+        errors.push(e);
+      }
+    }
+
+    // get back 4 responses for 5 requests
+    expect(responses.length).toEqual(requests.length - 1);
+
+    // expect to have failed once
+    expect(errors.length).toEqual(1);
+    expect(errors.at(0)).toEqual(new Error('TIMEOUT'));
   });
 });

--- a/src/utils/fetchWithTimeout.ts
+++ b/src/utils/fetchWithTimeout.ts
@@ -16,7 +16,8 @@ export const fetchWithTimeout = (
     }
     throw error;
   });
-  // abort promise if it cas not been completed after ms
+  // abort promise if it has not been completed after ms
   const timeout = setTimeout(() => controller.abort(), ms);
+
   return promise.finally(() => clearTimeout(timeout));
 };


### PR DESCRIPTION
references #79 

### overview
After the previous release we added the possibility to add custom timeouts to overwrite the class timeout, this pr adds tests for that. 

- goal of sdk test is to see you can customize timeout in class functions
- updated fetch with timeout tests to use a temporary http server and added stress tests