### PR TITLE
fix fetch request to withdraw

### DIFF
--- a/src/api/account/withdraw.ts
+++ b/src/api/account/withdraw.ts
@@ -29,7 +29,7 @@ export const withdraw = async (
     {
       method: 'POST',
       headers: getHeaders(payload.apiToken),
-      body: JSON.stringify({ body })
+      body: JSON.stringify(body)
     }
   );
 


### PR DESCRIPTION
### overview
we were sending all the parameters inside the body property and the node does not expect a body property