### PR TITLE
fix open handle for jest test on sdk

### DIFF
--- a/src/sdk.spec.ts
+++ b/src/sdk.spec.ts
@@ -2,6 +2,11 @@ import nock from 'nock';
 import { HoprSDK } from './sdk';
 
 describe('test sdk class', function () {
+  afterEach(() => {
+    nock.abortPendingRequests();
+    nock.cleanAll();
+  });
+
   it('should be able to overwrite timeout', async function () {
     const apiEndpoint = new URL('https://example.com');
     const apiToken = 'token';


### PR DESCRIPTION
### overview
`yarn test` was failing because an open handle

```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  Timeout

       7 | ) => {
       8 |   const controller = new AbortController();
    >  9 |   const promise = fetch(apiEndpoint, {
         |                        ^
      10 |     ...options,
      11 |     signal: controller.signal
      12 |   }).catch((error) => {

      at new InterceptedRequestRouter (node_modules/nock/lib/intercepted_request_router.js:78:13)
      at new OverriddenClientRequest (node_modules/nock/lib/intercept.js:286:25)
      at node_modules/nock/lib/intercept.js:423:14
      at module.request (node_modules/nock/lib/common.js:96:14)
      at node_modules/node-fetch/lib/index.js:1468:15
      at fetch (node_modules/node-fetch/lib/index.js:1437:9)
      at fetch (node_modules/cross-fetch/dist/node-ponyfill.js:10:20)
      at fetchWithTimeout (src/utils/fetchWithTimeout.ts:9:24)
      at src/api/messages/sendMessage.ts:32:45
      at src/api/messages/sendMessage.ts:8:71
      at Object.<anonymous>.__awaiter (src/api/messages/sendMessage.ts:4:12)
      at sendMessage (src/api/messages/sendMessage.ts:23:22)
      at MessagesAdapter.<anonymous> (src/api/messages/adapter.ts:41:23)
      at src/api/messages/adapter.ts:8:71
      at Object.<anonymous>.__awaiter (src/api/messages/adapter.ts:4:12)
      at MessagesAdapter.sendMessage (src/api/messages/adapter.ts:32:16)
      at Object.<anonymous> (src/sdk.spec.ts:24:24)
      at src/sdk.spec.ts:8:71
      at Object.<anonymous>.__awaiter (src/sdk.spec.ts:4:12)
      at Object.<anonymous> (src/sdk.spec.ts:22:16)
```

this pr should fix that