### PR TITLE
Update peers and messages

### DIFF
--- a/e2e/node.spec.ts
+++ b/e2e/node.spec.ts
@@ -27,6 +27,7 @@ describe('Node E2E Tests', function () {
     const expectedPeer: GetPeersResponseType['connected'][0] = {
       quality: expect.any(Number),
       peerId: expect.any(String),
+      peerAddress: expect.any(String),
       multiAddr: expect.any(String),
       heartbeats: expect.objectContaining({
         sent: expect.any(Number),

--- a/src/api/messages/popAllMessages.spec.ts
+++ b/src/api/messages/popAllMessages.spec.ts
@@ -4,7 +4,6 @@ import {
   PopMessageResponseType
 } from '../../types';
 import { APIError } from '../../utils';
-import { popMessage } from './popMessage';
 import { popAllMessages } from './popAllMessages';
 
 const API_ENDPOINT = 'http://localhost:3001';
@@ -23,8 +22,7 @@ describe('test popAllMessages', () => {
         messages: [
           {
             tag: 12,
-            body: 'This is a HOPR message.',
-            receivedAt: 1324284684614
+            body: 'This is a HOPR message.'
           }
         ]
       } as PopAllMessagesResponseType);
@@ -45,8 +43,7 @@ describe('test popAllMessages', () => {
         messages: [
           {
             tag: 12,
-            body: 'This is a HOPR message.',
-            receivedAt: 1324284684614
+            body: 'This is a HOPR message.'
           }
         ]
       } as PopAllMessagesResponseType);

--- a/src/api/node/getPeers.spec.ts
+++ b/src/api/node/getPeers.spec.ts
@@ -11,42 +11,44 @@ describe('test getPeers', function () {
     nock.cleanAll();
   });
   it('handles successful response', async function () {
-    nock(API_ENDPOINT)
-      .get(`/api/v3/node/peers`)
-      .reply(200, {
-        connected: [
-          {
-            peerId: '16Uiu2HAmVfV4GKQhdECMqYmUMGLy84RjTJQxTWDcmUX5847roBar',
-            multiAddr:
-              '/p2p/16Uiu2HAmVLfzSLQoLtCGSfQv5ac2GTQmMuxXFkZZgrmuirfT8gaJ',
-            heartbeats: {
-              sent: 10,
-              success: 8
-            },
-            lastSeen: 1646410980793,
-            quality: 0.8,
-            backoff: 0,
-            isNew: true,
-            reportedVersion: '1.92.12'
-          }
-        ],
-        announced: [
-          {
-            peerId: '16Uiu2HAmVfV4GKQhdECMqYmUMGLy84RjTJQxTWDcmUX5847roBar',
-            multiAddr:
-              '/p2p/16Uiu2HAmVLfzSLQoLtCGSfQv5ac2GTQmMuxXFkZZgrmuirfT8gaJ',
-            heartbeats: {
-              sent: 10,
-              success: 8
-            },
-            lastSeen: 1646410980793,
-            quality: 0.8,
-            backoff: 0,
-            isNew: true,
-            reportedVersion: '1.92.12'
-          }
-        ]
-      } as GetPeersResponseType);
+    const expectedResponse: GetPeersResponseType = {
+      connected: [
+        {
+          peerId: '16Uiu2HAmVfV4GKQhdECMqYmUMGLy84RjTJQxTWDcmUX5847roBar',
+          peerAddress: '0x0987654321098765432109876543210987654321',
+          multiAddr:
+            '/p2p/16Uiu2HAmVLfzSLQoLtCGSfQv5ac2GTQmMuxXFkZZgrmuirfT8gaJ',
+          heartbeats: {
+            sent: 10,
+            success: 8
+          },
+          lastSeen: 1646410980793,
+          quality: 0.8,
+          backoff: 0,
+          isNew: true,
+          reportedVersion: '1.92.12'
+        }
+      ],
+      announced: [
+        {
+          peerId: '16Uiu2HAmVfV4GKQhdECMqYmUMGLy84RjTJQxTWDcmUX5847roBar',
+          peerAddress: '0x0987654321098765432109876543210987654321',
+          multiAddr:
+            '/p2p/16Uiu2HAmVLfzSLQoLtCGSfQv5ac2GTQmMuxXFkZZgrmuirfT8gaJ',
+          heartbeats: {
+            sent: 10,
+            success: 8
+          },
+          lastSeen: 1646410980793,
+          quality: 0.8,
+          backoff: 0,
+          isNew: true,
+          reportedVersion: '1.92.12'
+        }
+      ]
+    };
+
+    nock(API_ENDPOINT).get(`/api/v3/node/peers`).reply(200, expectedResponse);
 
     const response = await getPeers({
       apiToken: API_TOKEN,

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -7,8 +7,7 @@ import { BasePayload } from './general';
 
 export const ReceivedMessage = z.object({
   tag: z.number().nonnegative(),
-  body: z.string(),
-  receivedAt: z.number().nonnegative()
+  body: z.string()
 });
 
 /**

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -13,6 +13,7 @@ export type GetPeersPayloadType = z.infer<typeof GetPeersPayload>;
 
 export const Peer = z.object({
   peerId: z.string(),
+  peerAddress: z.string(),
   multiAddr: z.string(),
   heartbeats: z.object({
     sent: z.number(),


### PR DESCRIPTION
### overview
peers now returns `peerAddress` and `messages` no longer returns `receivedAt`.