### PR TITLE
allow undefined payload for HoprSdk

### DIFF
--- a/src/api/account/adapter.ts
+++ b/src/api/account/adapter.ts
@@ -46,12 +46,12 @@ export class AccountAdapter {
    * @returns — A promise that resolves with an object containing the HOPR and native addresses.
    */
   public async getAddresses(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getAddresses({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
@@ -60,12 +60,12 @@ export class AccountAdapter {
    * @returns — A Promise that resolves with an object containing the HOPR and native balances.
    */
   public async getBalances(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getBalances({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
@@ -74,12 +74,12 @@ export class AccountAdapter {
    * @returns — A Promise that resolves to the HOPR address.
    */
   public async getHoprAddress(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getHoprAddress({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
@@ -88,12 +88,12 @@ export class AccountAdapter {
    * @returns — A Promise that resolves to a string representing the HOPR balance.
    */
   public async getHoprBalance(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getHoprBalance({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
@@ -102,12 +102,12 @@ export class AccountAdapter {
    * @returns — A Promise that resolves to the native address.
    */
   public async getNativeAddress(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getNativeAddress({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
@@ -116,12 +116,12 @@ export class AccountAdapter {
    * @returns — A Promise that resolves with a string representing the native balance.
    */
   public async getNativeBalance(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getNativeBalance({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
   /**

--- a/src/api/aliases/adapter.ts
+++ b/src/api/aliases/adapter.ts
@@ -45,12 +45,12 @@ export class AliasesAdapter {
    * @returns An object with alias names as keys and the peerId associated with the alias.
    */
   public async getAliases(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ): Promise<Record<string, string> | undefined> {
     return getAliases({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 

--- a/src/api/node/adapter.ts
+++ b/src/api/node/adapter.ts
@@ -38,53 +38,53 @@ export class NodeAdapter {
   }
 
   public async getEntryNodes(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getEntryNodes({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
   public async getInfo(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getInfo({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
   public async getMetrics(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getMetrics({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
   public async getPeers(
-    payload: RemoveBasicAuthenticationPayloadType<GetPeersPayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<GetPeersPayloadType>
   ) {
     return getPeers({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout,
-      quality: payload.quality
+      timeout: payload?.timeout ?? this.timeout,
+      quality: payload?.quality
     });
   }
 
   public async getVersion(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getVersion({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 }

--- a/src/api/settings/adapter.ts
+++ b/src/api/settings/adapter.ts
@@ -35,12 +35,12 @@ export class SettingsAdapter {
   }
 
   public async getSettings(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getSettings({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 

--- a/src/api/tickets/adapter.ts
+++ b/src/api/tickets/adapter.ts
@@ -35,22 +35,22 @@ export class TicketsAdapter {
   }
 
   public async getStatistics(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getStatistics({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
   public async getTickets(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getTickets({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 
@@ -59,12 +59,12 @@ export class TicketsAdapter {
    * This operation may take more than 5 minutes to complete as it involves on-chain operations.
    */
   public async redeemTickets(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return redeemTickets({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 }

--- a/src/api/tokens/adapter.ts
+++ b/src/api/tokens/adapter.ts
@@ -87,12 +87,12 @@ export class TokensAdapter {
    * @returns A Promise that resolves to an object with the token info.
    */
   public async getToken(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return getToken({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 }

--- a/src/flows/adapter.ts
+++ b/src/flows/adapter.ts
@@ -138,12 +138,12 @@ export class FlowsAdapter {
    *   - `redeemedTickets`: A boolean value indicating whether the tickets were redeemed successfully.
    */
   public async closeEverything(
-    payload: RemoveBasicAuthenticationPayloadType<BasePayloadType>
+    payload?: RemoveBasicAuthenticationPayloadType<BasePayloadType>
   ) {
     return closeEverything({
       apiEndpoint: this.apiEndpoint,
       apiToken: this.apiToken,
-      timeout: payload.timeout ?? this.timeout
+      timeout: payload?.timeout ?? this.timeout
     });
   }
 }


### PR DESCRIPTION
### overview
provide better ux for sdk users.

### before
```
    this.sdk.api.account.getAddresses({})
```

### after
```
    this.sdk.api.account.getAddresses()
```

this change allows some adapter functions to receive undefined without changing how the pure functions work.