### PR TITLE
added indexer info to getInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-sdk",
-  "version": "2.1.5-beta.1",
+  "version": "2.1.6",
   "description": "A SDK for HOPRd's Rest API functions",
   "author": "HOPR Association",
   "license": "GPL-3.0",

--- a/src/api/node/getInfo.spec.ts
+++ b/src/api/node/getInfo.spec.ts
@@ -25,7 +25,8 @@ describe('test getInfo', function () {
         hoprManagementModule: '0x39b0445b32f5a544eb7917912f5f837bd061be4c',
         hoprNodeSafe: '0x0361a040acb376dd7e5a4643e5a4c7ae9d20c834',
         indexerBlock: 35346732,
-        indexerChecksum: "0xe780bd95f350e96fe30e98d17560ade3c892f0d3bd75d681f99b0d3c1690517d",
+        indexerChecksum:
+          '0xe780bd95f350e96fe30e98d17560ade3c892f0d3bd75d681f99b0d3c1690517d',
         indexBlockPrevChecksum: 35611556,
         isEligible: false,
         connectivityStatus: 'Orange',

--- a/src/api/node/getInfo.spec.ts
+++ b/src/api/node/getInfo.spec.ts
@@ -24,6 +24,9 @@ describe('test getInfo', function () {
         hoprNodeSafeRegistry: '0x3E7c4720934ff6A9FE122Cb761f36a11E9b848D9',
         hoprManagementModule: '0x39b0445b32f5a544eb7917912f5f837bd061be4c',
         hoprNodeSafe: '0x0361a040acb376dd7e5a4643e5a4c7ae9d20c834',
+        indexerBlock: 35346732,
+        indexerChecksum: "0xe780bd95f350e96fe30e98d17560ade3c892f0d3bd75d681f99b0d3c1690517d",
+        indexBlockPrevChecksum: 35611556,
         isEligible: false,
         connectivityStatus: 'Orange',
         channelClosurePeriod: 5

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -55,6 +55,9 @@ export const GetInfoResponse = z.object({
   hoprNodeSafeRegistry: z.string().optional(),
   hoprManagementModule: z.string(),
   hoprNodeSafe: z.string(),
+  indexerBlock: z.number().optional(), //from HORPd 2.1.3
+  indexerChecksum: z.string().optional(), //from HORPd 2.1.3
+  indexBlockPrevChecksum: z.number().optional(), //from HORPd 2.1.5
   connectivityStatus: z.enum(['Unknown', 'Red', 'Orange', 'Yellow', 'Green']),
   isEligible: z.boolean(),
   channelClosurePeriod: z.number()


### PR DESCRIPTION
New entries from 2.1.3 and 2.1.5 HOPRds:

```
  indexerBlock: z.number().optional(), //from HORPd 2.1.3
  indexerChecksum: z.string().optional(), //from HORPd 2.1.3
  indexBlockPrevChecksum: z.number().optional(), //from HORPd 2.1.5
```