### PR TITLE
allow custom tags and next version release closing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,14 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Next version type'
+        description: 'Next version type: [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]'
+        required: true
+        type: string
+        default: 'patch'
+      release_tag:
+        description: 'NPM release tag'
         required: true
         type: choice
-        default: 'patch'
+        default: 'latest'
         options:
-          - patch
-          - minor
-          - major
+          - latest
+          - beta
 
 concurrency:
   group: release
@@ -104,7 +108,7 @@ jobs:
 
       - name: Publish to Google Artifact Registry
         if: steps.unpublish.outputs.already_released != 'true'
-        run: yarn publish --tag latest
+        run: yarn publish --tag ${{ inputs.release_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
 
@@ -118,7 +122,7 @@ jobs:
 
       - name: Publish to npm
         run: |
-          yarn publish --no-git-tag-version --tag latest
+          yarn publish --no-git-tag-version --tag ${{ inputs.release_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter `release_tag` for specifying NPM release tags.
- **Enhancements**
	- Updated `release_type` input for more detailed versioning options.
	- Modified publishing commands to utilize the `release_tag` input, enhancing flexibility in release tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->