### PR TITLE
Use bigger runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   release:
     name: Close release
-    runs-on: self-hosted-hoprnet-small
+    runs-on: self-hosted-hoprnet-big
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The release workflow fails with an out of memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the runner specification for the release job to a larger self-hosted runner.
	- Maintained existing workflow steps for building, testing, and publishing without structural changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->