### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-sdk",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "A SDK for HOPRd's Rest API functions",
   "author": "HOPR Association",
   "license": "GPL-3.0",


### PR DESCRIPTION
Latest clore release failed: https://github.com/hoprnet/hopr-sdk/actions/runs/11611491870/job/32332949373
Needs to do it manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version number of the `@hoprnet/hopr-sdk` package from 2.1.9 to 2.1.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->