### PR TITLE
Fix creating the release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,6 +105,7 @@ jobs:
       - name: Publish to Google Artifact Registry
         if: steps.unpublish.outputs.already_released != 'true'
         run: |
+          npm run login
           yarn publish --non-interactive --registry=https://europe-west3-npm.pkg.dev/hoprassociation/npm/ --tag release-candidate
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-sdk",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "A SDK for HOPRd's Rest API functions",
   "author": "HOPR Association",
   "license": "GPL-3.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publish pipeline to include a pre-publish authentication step before pushing to Google Artifact Registry, with existing environment and registry settings unchanged.
  * Incremented package version from 3.0.0 to 3.0.2 to reflect maintenance updates. No functional or API changes are included in this release for end users at this time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->