### PR TITLE
Fix npm publish workflow

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: hoprnet/hopr-workflows/actions/setup-node-js@setup-node-js-v1
         with:
-          node_version: 22.x
+          node_version: 24.x
       - name: Create docs
         run: |
           rm -rf docs/*

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 22.x
           - 24.x
     uses: ./.github/workflows/build.yaml
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         node_version:
+          - 22.x
           - 24.x
     uses: ./.github/workflows/build.yaml
     with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ on:
       node_version:
         required: false
         type: string
-        default: '24.x'
+        default: '24.x' # Requires 24.x for publishing to npm with OIDC authentication
     secrets:
       cachix_auth_token:
         required: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,9 +96,10 @@ jobs:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false  # never use caching in release builds
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Building
-        run: |
-          yarn build
+        run: yarn build
       - name: Publish release candidate to npm
         run: |
           npm config set --location project @hoprnet:registry https://registry.npmjs.org/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,5 +90,6 @@ jobs:
         if: inputs.version_type == 'release'
         run: |
           npm config set --location project @hoprnet:registry https://registry.npmjs.org/
+          npm config delete --location project //registry.npmjs.org/:_authToken
           npm publish --provenance --access public --tag release-candidate
           git checkout .npmrc

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   publish-google:
-    name: Publish Google Artifact Registry
+    name: Google Artifact Registry
     runs-on: depot-ubuntu-24.04-4
     permissions:
       id-token: write
@@ -80,7 +80,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
   publish-npm:
-    name: Publish NPM
+    name: NPM
     needs: publish-google
     if: inputs.version_type == 'release'
     runs-on: depot-ubuntu-24.04-4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -103,9 +103,7 @@ jobs:
       - name: Building
         run: yarn build
       - name: Publish release candidate to npm
-        run: |
-          npm config set --location project @hoprnet:registry https://registry.npmjs.org/
-          npm publish --provenance --access public --tag release-candidate --verbose
+        run: npm publish --provenance --access public --tag release-candidate --verbose
       - name: Print npm debug log
         if: failure()
         run: cat /home/runner/.npm/_logs/*.log

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -100,7 +100,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
       - name: Upgrade npm for OIDC Trusted Publishing
-        run: npm install -g npm@latest
+        run: |
+          npm install --global npm@^11.5.1
+          npm --version
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Building

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ on:
       node_version:
         required: false
         type: string
-        default: '22.x'
+        default: '24.x'
     secrets:
       cachix_auth_token:
         required: true
@@ -67,7 +67,7 @@ jobs:
           yarn publish --registry=https://europe-west3-npm.pkg.dev/hoprassociation/npm/ --no-git-tag-version --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
-      - name: Publish release candidate
+      - name: Publish release candidate to google
         if: inputs.version_type == 'release'
         run: |
           already_released=$(gcloud artifacts versions list --repository=npm --location=europe-west3 --project=hoprassociation --package="@hoprnet/hopr-sdk" --format=json 2>/dev/null | jq -r ' .[] | select(.name | contains("${{ steps.version.outputs.build_version }}")).name' | grep '${{ steps.version.outputs.build_version }}$' | wc -l)
@@ -82,7 +82,7 @@ jobs:
 
   publish-npm:
     name: NPM
-    # needs: publish-google
+    needs: publish-google
     if: inputs.version_type == 'release'
     runs-on: ubuntu-latest
     permissions:
@@ -96,17 +96,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
-          node-version: 24.x
+          node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
-      - name: Upgrade npm for OIDC Trusted Publishing
-        run: npm --version
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Building
         run: yarn build
       - name: Publish release candidate to npm
-        run: npm publish --provenance --access public --tag release-candidate --verbose
-      - name: Print npm debug log
-        if: failure()
-        run: cat /home/runner/.npm/_logs/*.log
+        run: npm publish --provenance --access public --tag release-candidate

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
           already_released=$(gcloud artifacts versions list --repository=npm --location=europe-west3 --project=hoprassociation --package="@hoprnet/hopr-sdk" --format=json 2>/dev/null | jq -r ' .[] | select(.name | contains("${{ steps.version.outputs.build_version }}")).name' | grep '${{ steps.version.outputs.build_version }}$' | wc -l)
           if [ "$already_released" -eq 0 ]; then
             npm run login
-            yarn publish --non-interactive --registry=https://europe-west3-npm.pkg.dev/hoprassociation/npm/ --tag release-candidate
+            yarn publish --registry=https://europe-west3-npm.pkg.dev/hoprassociation/npm/ --no-git-tag-version --tag release-candidate
           else
             echo "Release already released in Artifact registry"
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,7 +84,7 @@ jobs:
     name: NPM
     needs: publish-google
     if: inputs.version_type == 'release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # We need to use ubuntu-latest here because of the npm publish command, which strictly requires Github's runners to publish to npm, and they don't support custom runners for now.
     permissions:
       id-token: write
       contents: read
@@ -97,7 +97,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version: ${{ inputs.node_version }}
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: https://registry.npmjs.org
           package-manager-cache: false
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,6 +90,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Remove rc files
+        run: rm -rf .npmrc .yarnrc
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
@@ -103,4 +105,7 @@ jobs:
       - name: Publish release candidate to npm
         run: |
           npm config set --location project @hoprnet:registry https://registry.npmjs.org/
-          npm publish --provenance --access public --tag release-candidate
+          npm publish --provenance --access public --tag release-candidate --verbose
+      - name: Print npm debug log
+        if: failure()
+        run: cat /home/runner/.npm/_logs/*.log

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -79,18 +79,9 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
-      - name: Setup Node.js for npm publish
-        if: inputs.version_type == 'release'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
-        with:
-          node-version: ${{ inputs.node_version }}
-          registry-url: https://registry.npmjs.org
-          package-manager-cache: false
       - name: Publish release candidate to npm
         if: inputs.version_type == 'release'
         run: |
           npm config set --location project @hoprnet:registry https://registry.npmjs.org/
           npm publish --provenance --access public --tag release-candidate
           git checkout .npmrc
-        env:
-          NODE_AUTH_TOKEN: ''

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -79,31 +79,4 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
-  publish-npm:
-    name: NPM
-    needs: publish-google
-    if: inputs.version_type == 'release'
-    runs-on: ubuntu-latest # Required by NPM OIDC login
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Remove rc files
-        run: rm -rf .npmrc .yarnrc
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
-        with:
-          node-version: ${{ inputs.node_version }}
-          registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false  # never use caching in release builds
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Building
-        run: yarn build
-      - name: Publish release candidate to npm
-        run: npm publish --provenance --access public --tag release-candidate --verbose
-      - name: Print npm debug log
-        if: failure()
-        run: cat /home/runner/.npm/_logs/*.log
+

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish Package
+  publish-google:
+    name: Publish Google Artifact Registry
     runs-on: depot-ubuntu-24.04-4
     permissions:
       id-token: write
@@ -67,7 +67,7 @@ jobs:
           yarn publish --registry=https://europe-west3-npm.pkg.dev/hoprassociation/npm/ --no-git-tag-version --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
-      - name: Publish release candidate version to Google Artifact Registry
+      - name: Publish release candidate
         if: inputs.version_type == 'release'
         run: |
           already_released=$(gcloud artifacts versions list --repository=npm --location=europe-west3 --project=hoprassociation --package="hopr-sdk" --format=json 2>/dev/null | jq -r ' .[] | select(.name | contains("${{ steps.version.outputs.build_version }}")).name' | grep '${{ steps.version.outputs.build_version }}$' | wc -l)
@@ -79,9 +79,27 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
+  publish-npm:
+    name: Publish NPM
+    needs: publish-google
+    if: inputs.version_type == 'release'
+    runs-on: depot-ubuntu-24.04-4
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
+        with:
+          node-version: ${{ inputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
+      - name: Building
+        run: |
+          yarn build
       - name: Publish release candidate to npm
-        if: inputs.version_type == 'release'
         run: |
           npm config set --location project @hoprnet:registry https://registry.npmjs.org/
           npm publish --provenance --access public --tag release-candidate
-          git checkout .npmrc

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -79,6 +79,10 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
+      - name: Prepare for npm publish
+        if: inputs.version_type == 'release'
+        run: |
+          rm -f .npmrc .yarnrc
       - name: Setup Node.js for npm publish
         if: inputs.version_type == 'release'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
@@ -89,7 +93,7 @@ jobs:
       - name: Publish release candidate to npm
         if: inputs.version_type == 'release'
         run: |
-          npm config set --location project @hoprnet:registry https://registry.npmjs.org/
-          npm config delete --location project //registry.npmjs.org/:_authToken
+          # npm config set --location project @hoprnet:registry https://registry.npmjs.org/
+          # npm config delete --location project //registry.npmjs.org/:_authToken
           npm publish --provenance --access public --tag release-candidate
-          git checkout .npmrc
+          # git checkout .npmrc

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -96,13 +96,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
-          node-version: ${{ inputs.node_version }}
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
       - name: Upgrade npm for OIDC Trusted Publishing
-        run: |
-          npm install --global npm@^11.5.1
-          npm --version
+        run: npm --version
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Building

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -79,10 +79,6 @@ jobs:
           fi
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
-      - name: Prepare for npm publish
-        if: inputs.version_type == 'release'
-        run: |
-          rm -f .npmrc .yarnrc
       - name: Setup Node.js for npm publish
         if: inputs.version_type == 'release'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
@@ -93,7 +89,8 @@ jobs:
       - name: Publish release candidate to npm
         if: inputs.version_type == 'release'
         run: |
-          # npm config set --location project @hoprnet:registry https://registry.npmjs.org/
-          # npm config delete --location project //registry.npmjs.org/:_authToken
+          npm config set --location project @hoprnet:registry https://registry.npmjs.org/
           npm publish --provenance --access public --tag release-candidate
-          # git checkout .npmrc
+          git checkout .npmrc
+        env:
+          NODE_AUTH_TOKEN: ''

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   publish-google:
-    name: Google Artifact Registry
+    name: Google
     runs-on: depot-ubuntu-24.04-4
     permissions:
       id-token: write
@@ -70,7 +70,7 @@ jobs:
       - name: Publish release candidate
         if: inputs.version_type == 'release'
         run: |
-          already_released=$(gcloud artifacts versions list --repository=npm --location=europe-west3 --project=hoprassociation --package="hopr-sdk" --format=json 2>/dev/null | jq -r ' .[] | select(.name | contains("${{ steps.version.outputs.build_version }}")).name' | grep '${{ steps.version.outputs.build_version }}$' | wc -l)
+          already_released=$(gcloud artifacts versions list --repository=npm --location=europe-west3 --project=hoprassociation --package="@hoprnet/hopr-sdk" --format=json 2>/dev/null | jq -r ' .[] | select(.name | contains("${{ steps.version.outputs.build_version }}")).name' | grep '${{ steps.version.outputs.build_version }}$' | wc -l)
           if [ "$already_released" -eq 0 ]; then
             npm run login
             yarn publish --non-interactive --registry=https://europe-west3-npm.pkg.dev/hoprassociation/npm/ --tag release-candidate

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -80,3 +80,33 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ steps.gcp.outputs.access_token }}
 
+  publish-npm:
+    name: NPM
+    # needs: publish-google
+    if: inputs.version_type == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Remove rc files
+        run: rm -rf .npmrc .yarnrc
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
+        with:
+          node-version: ${{ inputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - name: Upgrade npm for OIDC Trusted Publishing
+        run: npm install -g npm@latest
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Building
+        run: yarn build
+      - name: Publish release candidate to npm
+        run: npm publish --provenance --access public --tag release-candidate --verbose
+      - name: Print npm debug log
+        if: failure()
+        run: cat /home/runner/.npm/_logs/*.log

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -83,7 +83,7 @@ jobs:
     name: NPM
     needs: publish-google
     if: inputs.version_type == 'release'
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: ubuntu-latest # Required by NPM OIDC login
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,24 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       node_version: '24'
+  publish:
+    name: Publish
+    needs:
+      - build
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish.yaml
+    with:
+      version_type: release
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
   release:
     name: Close release
     needs:
       - build
+      - publish
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
@@ -48,17 +62,3 @@ jobs:
           zulip_topic: Releases
           gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
           github_token: ${{ secrets.GH_RUNNER_TOKEN }}
-  publish:
-    name: Publish
-    needs:
-      - build
-      - release
-    permissions:
-      id-token: write
-      contents: read
-    uses: ./.github/workflows/publish.yaml
-    with:
-      version_type: release
-    secrets:
-      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
   #   name: Build
   #   uses: ./.github/workflows/build.yaml
   #   with:
-  #     node_version: '22'
+  #     node_version: '24'
   # release:
   #   name: Close release
   #   needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,56 +48,60 @@ jobs:
   #         zulip_topic: Releases
   #         gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
   #         github_token: ${{ secrets.GH_RUNNER_TOKEN }}
-  # publish:
-  #   name: Publish
-  #   # needs:
-  #   #   - build
-  #   #   - release
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   uses: ./.github/workflows/publish.yaml
-  #   with:
-  #     version_type: release
-  #   secrets:
-  #     cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-  #     gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-  publish-npm:
-    name: NPM
-    # needs: publish-google
-    runs-on: ubuntu-latest # Required by NPM OIDC login
+  publish:
+    name: Publish
+    # needs:
+    #   - build
+    #   - release
     permissions:
       id-token: write
       contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Remove rc files
-        run: rm -rf .npmrc .yarnrc
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
-        with:
-          node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false  # never use caching in release builds
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-      - name: Building
-        run: yarn build
-      - name: Debug GitHub OIDC claims
-        run: |
-          token_json=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")
-          id_token=$(echo "$token_json" | jq -r '.value')
-          echo "$id_token" | awk -F. '{print $2}' | base64 -d 2>/dev/null | jq '{aud, sub, workflow, workflow_ref, job_workflow_ref, repository, repository_owner, repository_visibility, runner_environment, event_name, ref}'
-      - name: Check npm OIDC exchange
-        run: |
-          token_json=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")
-          id_token=$(echo "$token_json" | jq -r '.value')
-          status=$(curl -sS -o /tmp/npm-oidc-response.json -w "%{http_code}" -X POST -H "Authorization: Bearer $id_token" https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@hoprnet%2fhopr-sdk)
-          echo "npm OIDC exchange status: $status"
-          cat /tmp/npm-oidc-response.json | jq .
-      - name: Publish release candidate to npm
-        run: npm publish --provenance --access public --tag release-candidate --verbose
-      - name: Print npm debug log
-        if: failure()
-        run: cat /home/runner/.npm/_logs/*.log
+    uses: ./.github/workflows/publish.yaml
+    with:
+      version_type: release
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+  # publish-npm:
+  #   name: NPM
+  #   # needs: publish-google
+  #   runs-on: ubuntu-latest # Required by NPM OIDC login
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #     - name: Remove rc files
+  #       run: rm -rf .npmrc .yarnrc
+  #     - name: Setup Node.js
+  #       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
+  #       with:
+  #         node-version: 22.x
+  #         registry-url: 'https://registry.npmjs.org'
+  #         package-manager-cache: false  # never use caching in release builds
+  #     - name: Upgrade npm for trusted publishing
+  #       run: |
+  #         npm install --global npm@^11.5.1
+  #         npm --version
+  #     - name: Install dependencies
+  #       run: yarn install --frozen-lockfile
+  #     - name: Building
+  #       run: yarn build
+  #     - name: Debug GitHub OIDC claims
+  #       run: |
+  #         token_json=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")
+  #         id_token=$(echo "$token_json" | jq -r '.value')
+  #         echo "$id_token" | awk -F. '{print $2}' | base64 -d 2>/dev/null | jq '{aud, sub, workflow, workflow_ref, job_workflow_ref, repository, repository_owner, repository_visibility, runner_environment, event_name, ref}'
+  #     - name: Check npm OIDC exchange
+  #       run: |
+  #         token_json=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")
+  #         id_token=$(echo "$token_json" | jq -r '.value')
+  #         status=$(curl -sS -o /tmp/npm-oidc-response.json -w "%{http_code}" -X POST -H "Authorization: Bearer $id_token" https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@hoprnet%2fhopr-sdk)
+  #         echo "npm OIDC exchange status: $status"
+  #         cat /tmp/npm-oidc-response.json | jq .
+  #     - name: Publish release candidate to npm
+  #       run: npm publish --provenance --access public --tag release-candidate --verbose
+  #     - name: Print npm debug log
+  #       if: failure()
+  #       run: cat /home/runner/.npm/_logs/*.log

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,6 +53,9 @@ jobs:
     # needs:
     #   - build
     #   - release
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish.yaml
     with:
       version_type: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,17 +48,44 @@ jobs:
   #         zulip_topic: Releases
   #         gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
   #         github_token: ${{ secrets.GH_RUNNER_TOKEN }}
-  publish:
-    name: Publish
-    # needs:
-    #   - build
-    #   - release
+  # publish:
+  #   name: Publish
+  #   # needs:
+  #   #   - build
+  #   #   - release
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   uses: ./.github/workflows/publish.yaml
+  #   with:
+  #     version_type: release
+  #   secrets:
+  #     cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+  #     gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+  publish-npm:
+    name: NPM
+    # needs: publish-google
+    runs-on: ubuntu-latest # Required by NPM OIDC login
     permissions:
       id-token: write
       contents: read
-    uses: ./.github/workflows/publish.yaml
-    with:
-      version_type: release
-    secrets:
-      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Remove rc files
+        run: rm -rf .npmrc .yarnrc
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Building
+        run: yarn build
+      - name: Publish release candidate to npm
+        run: npm publish --provenance --access public --tag release-candidate --verbose
+      - name: Print npm debug log
+        if: failure()
+        run: cat /home/runner/.npm/_logs/*.log

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,6 @@ jobs:
   build:
     name: Build
     uses: ./.github/workflows/build.yaml
-    with:
-      node_version: '24'
   publish:
     name: Publish
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,41 +18,41 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # build:
-  #   name: Build
-  #   uses: ./.github/workflows/build.yaml
-  #   with:
-  #     node_version: '24'
-  # release:
-  #   name: Close release
-  #   needs:
-  #     - build
-  #   runs-on: depot-ubuntu-24.04
-  #   permissions:
-  #     contents: write
-  #   outputs:
-  #     released_version: ${{ steps.release.outputs.current_version }}
-  #   steps:
-  #     - name: Release version
-  #       id: release
-  #       uses: hoprnet/hopr-workflows/actions/release-version@release-version-v3
-  #       with:
-  #         source_branch: ${{ github.ref_name }}
-  #         file: package.json
-  #         release_type: ${{ inputs.release_type }}
-  #         cachix_cache_name: hopr-sdk
-  #         cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-  #         zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
-  #         zulip_email: ${{ secrets.ZULIP_EMAIL }}
-  #         zulip_channel: Products
-  #         zulip_topic: Releases
-  #         gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-  #         github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yaml
+    with:
+      node_version: '24'
+  release:
+    name: Close release
+    needs:
+      - build
+    runs-on: depot-ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      released_version: ${{ steps.release.outputs.current_version }}
+    steps:
+      - name: Release version
+        id: release
+        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v3
+        with:
+          source_branch: ${{ github.ref_name }}
+          file: package.json
+          release_type: ${{ inputs.release_type }}
+          cachix_cache_name: hopr-sdk
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
+          zulip_email: ${{ secrets.ZULIP_EMAIL }}
+          zulip_channel: Products
+          zulip_topic: Releases
+          gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+          github_token: ${{ secrets.GH_RUNNER_TOKEN }}
   publish:
     name: Publish
-    # needs:
-    #   - build
-    #   - release
+    needs:
+      - build
+      - release
     permissions:
       id-token: write
       contents: read
@@ -62,46 +62,3 @@ jobs:
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-  # publish-npm:
-  #   name: NPM
-  #   # needs: publish-google
-  #   runs-on: ubuntu-latest # Required by NPM OIDC login
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-  #     - name: Remove rc files
-  #       run: rm -rf .npmrc .yarnrc
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
-  #       with:
-  #         node-version: 22.x
-  #         registry-url: 'https://registry.npmjs.org'
-  #         package-manager-cache: false  # never use caching in release builds
-  #     - name: Upgrade npm for trusted publishing
-  #       run: |
-  #         npm install --global npm@^11.5.1
-  #         npm --version
-  #     - name: Install dependencies
-  #       run: yarn install --frozen-lockfile
-  #     - name: Building
-  #       run: yarn build
-  #     - name: Debug GitHub OIDC claims
-  #       run: |
-  #         token_json=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")
-  #         id_token=$(echo "$token_json" | jq -r '.value')
-  #         echo "$id_token" | awk -F. '{print $2}' | base64 -d 2>/dev/null | jq '{aud, sub, workflow, workflow_ref, job_workflow_ref, repository, repository_owner, repository_visibility, runner_environment, event_name, ref}'
-  #     - name: Check npm OIDC exchange
-  #       run: |
-  #         token_json=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")
-  #         id_token=$(echo "$token_json" | jq -r '.value')
-  #         status=$(curl -sS -o /tmp/npm-oidc-response.json -w "%{http_code}" -X POST -H "Authorization: Bearer $id_token" https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@hoprnet%2fhopr-sdk)
-  #         echo "npm OIDC exchange status: $status"
-  #         cat /tmp/npm-oidc-response.json | jq .
-  #     - name: Publish release candidate to npm
-  #       run: npm publish --provenance --access public --tag release-candidate --verbose
-  #     - name: Print npm debug log
-  #       if: failure()
-  #       run: cat /home/runner/.npm/_logs/*.log

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,6 +84,18 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Building
         run: yarn build
+      - name: Debug GitHub OIDC claims
+        run: |
+          token_json=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")
+          id_token=$(echo "$token_json" | jq -r '.value')
+          echo "$id_token" | awk -F. '{print $2}' | base64 -d 2>/dev/null | jq '{aud, sub, workflow, workflow_ref, job_workflow_ref, repository, repository_owner, repository_visibility, runner_environment, event_name, ref}'
+      - name: Check npm OIDC exchange
+        run: |
+          token_json=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")
+          id_token=$(echo "$token_json" | jq -r '.value')
+          status=$(curl -sS -o /tmp/npm-oidc-response.json -w "%{http_code}" -X POST -H "Authorization: Bearer $id_token" https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@hoprnet%2fhopr-sdk)
+          echo "npm OIDC exchange status: $status"
+          cat /tmp/npm-oidc-response.json | jq .
       - name: Publish release candidate to npm
         run: npm publish --provenance --access public --tag release-candidate --verbose
       - name: Print npm debug log

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,41 +18,41 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build
-    uses: ./.github/workflows/build.yaml
-    with:
-      node_version: '22'
-  release:
-    name: Close release
-    needs:
-      - build
-    runs-on: depot-ubuntu-24.04
-    permissions:
-      contents: write
-    outputs:
-      released_version: ${{ steps.release.outputs.current_version }}
-    steps:
-      - name: Release version
-        id: release
-        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v3
-        with:
-          source_branch: ${{ github.ref_name }}
-          file: package.json
-          release_type: ${{ inputs.release_type }}
-          cachix_cache_name: hopr-sdk
-          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
-          zulip_email: ${{ secrets.ZULIP_EMAIL }}
-          zulip_channel: Products
-          zulip_topic: Releases
-          gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-          github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+  # build:
+  #   name: Build
+  #   uses: ./.github/workflows/build.yaml
+  #   with:
+  #     node_version: '22'
+  # release:
+  #   name: Close release
+  #   needs:
+  #     - build
+  #   runs-on: depot-ubuntu-24.04
+  #   permissions:
+  #     contents: write
+  #   outputs:
+  #     released_version: ${{ steps.release.outputs.current_version }}
+  #   steps:
+  #     - name: Release version
+  #       id: release
+  #       uses: hoprnet/hopr-workflows/actions/release-version@release-version-v3
+  #       with:
+  #         source_branch: ${{ github.ref_name }}
+  #         file: package.json
+  #         release_type: ${{ inputs.release_type }}
+  #         cachix_cache_name: hopr-sdk
+  #         cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+  #         zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
+  #         zulip_email: ${{ secrets.ZULIP_EMAIL }}
+  #         zulip_channel: Products
+  #         zulip_topic: Releases
+  #         gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
+  #         github_token: ${{ secrets.GH_RUNNER_TOKEN }}
   publish:
     name: Publish
-    needs:
-      - build
-      - release
+    # needs:
+    #   - build
+    #   - release
     uses: ./.github/workflows/publish.yaml
     with:
       version_type: release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-sdk",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "A SDK for HOPRd's Rest API functions",
   "author": "HOPR Association",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.4.3"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "yarn@1.22.19",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "^5.4.3"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "yarn@1.22.19",
   "dependencies": {


### PR DESCRIPTION
The NPM publish workflow was failing because it was required a NPM_TOKEN. The npm tokens expires every 90 days which makes it quite error prone.
The publish method to NPN has been change to use OIDC so there is no need to have a token that expires, and it's linked to the workflow file `release.yaml`
The usage of OIDC in npm required a higher npm version, and that`s why I upgraded the project to use NodeJS 24.
Version has been bumped to 3.0.8 because during testing I published 3.0.7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added npm registry publishing support for releases.
  * Introduced separate Google and npm publishing flows for releases.

* **Chores**
  * Version bumped to 3.0.8.
  * Updated minimum Node.js requirement to 24.0.0 and migrated build/publish workflows to Node.js 24.x.
  * Adjusted Google publishing path and release candidate publication flow.
  * Added enhanced publish permissions for release workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->