### PR TITLE
feat(ci): migrate workflows to Workload Identity Provider auth

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -18,12 +18,14 @@ jobs:
   publish:
     name: Publish
     needs: build
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish.yaml
     with:
       version_type: pr
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
   docs:
     name: Docs
     needs: build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,9 +23,11 @@ jobs:
   publish:
     name: Publish
     needs: build
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish.yaml
     with:
       version_type: commit
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
           node_version: ${{ inputs.node_version }}
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # setup-gcp-v4
         with:
           login_artifact_registry: 'true'
       - name: Updates build version

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,8 +13,6 @@ on:
     secrets:
       cachix_auth_token:
         required: true
-      gcp_service_account:
-        required: true
 concurrency:
   group: publish
   cancel-in-progress: false
@@ -40,9 +38,8 @@ jobs:
           node_version: ${{ inputs.node_version }}
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@setup-gcp-v3
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4
         with:
-          google_credentials: ${{ secrets.gcp_service_account }}
           login_artifact_registry: 'true'
       - name: Updates build version
         id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,6 @@ jobs:
       version_type: release
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
   release:
     name: Close release
     needs:
@@ -42,12 +41,13 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     outputs:
       released_version: ${{ steps.release.outputs.current_version }}
     steps:
       - name: Release version
         id: release
-        uses: hoprnet/hopr-workflows/actions/release-version@release-version-v3
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1
         with:
           source_branch: ${{ github.ref_name }}
           file: package.json
@@ -58,5 +58,4 @@ jobs:
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_channel: Products
           zulip_topic: Releases
-          gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-          github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+          github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Release version
         id: release
-        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
         with:
           source_branch: ${{ github.ref_name }}
           file: package.json


### PR DESCRIPTION
## Summary

- Pins all `hoprnet/hopr-workflows` action/workflow refs to new OIDC-enabled SHAs
- Removes legacy `gcp_service_account`, `google_credentials`, and `GH_RUNNER_TOKEN` PAT from workflow inputs
- Adds `id-token: write` permission to every consumer job for OIDC token minting
- Adds `github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}` to all `release-version` invocations

Part of the org-wide WIF migration following the GitHub security incident. Reference: hoprnet/blokli#377