### PR TITLE
feat(ci): add actionlint + pinact pre-commit hooks for workflow validation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-24.04
+    - depot-ubuntu-24.04-4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: hoprnet/hopr-workflows/actions/setup-node-js@setup-node-js-v1
+        uses: hoprnet/hopr-workflows/actions/setup-node-js@15db9fb5571957317b77567abef997b1554f2fbb # v1
         with:
           node_version: ${{ inputs.node_version }}
       - name: Installing dependencies

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        uses: hoprnet/hopr-workflows/actions/setup-node-js@setup-node-js-v1
+        uses: hoprnet/hopr-workflows/actions/setup-node-js@15db9fb5571957317b77567abef997b1554f2fbb # v1
         with:
           node_version: 24.x
       - name: Create docs

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,22 +28,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Nix
-        uses: hoprnet/hopr-workflows/actions/setup-nix@setup-nix-v1
+        uses: hoprnet/hopr-workflows/actions/setup-nix@c8d45034bb33307dfda3b4dfcd1fc4000cadc05a # v1
         with:
           cachix_cache_name: hopr-sdk
           cachix_auth_token: ${{ secrets.cachix_auth_token }}
       - name: Setup Node.js
-        uses: hoprnet/hopr-workflows/actions/setup-node-js@setup-node-js-v1
+        uses: hoprnet/hopr-workflows/actions/setup-node-js@15db9fb5571957317b77567abef997b1554f2fbb # v1
         with:
           node_version: ${{ inputs.node_version }}
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # setup-gcp-v4
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # 0.9.4
         with:
           login_artifact_registry: 'true'
       - name: Updates build version
         id: version
-        uses: hoprnet/hopr-workflows/actions/set-build-version@set-build-version-v2
+        uses: hoprnet/hopr-workflows/actions/set-build-version@2855f448149188cd9c4da41f0a6cbdf4f3d664a1 # v2
         with:
           file: package.json
           version_type: ${{ inputs.version_type }}
@@ -67,7 +67,7 @@ jobs:
       - name: Publish release candidate to google
         if: inputs.version_type == 'release'
         run: |
-          already_released=$(gcloud artifacts versions list --repository=npm --location=europe-west3 --project=hoprassociation --package="@hoprnet/hopr-sdk" --format=json 2>/dev/null | jq -r ' .[] | select(.name | contains("${{ steps.version.outputs.build_version }}")).name' | grep '${{ steps.version.outputs.build_version }}$' | wc -l)
+          already_released=$(gcloud artifacts versions list --repository=npm --location=europe-west3 --project=hoprassociation --package="@hoprnet/hopr-sdk" --format=json 2>/dev/null | jq -r ' .[] | select(.name | contains("${{ steps.version.outputs.build_version }}")).name' | grep -c '${{ steps.version.outputs.build_version }}$')
           if [ "$already_released" -eq 0 ]; then
             npm run login
             yarn publish --registry=https://europe-west3-npm.pkg.dev/hoprassociation/npm/ --no-git-tag-version --tag release-candidate
@@ -91,7 +91,7 @@ jobs:
       - name: Remove rc files
         run: rm -rf .npmrc .yarnrc
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node_version }}
           registry-url: https://registry.npmjs.org

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,13 +34,34 @@
         "type": "github"
       }
     },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757347588,
-        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -34,10 +71,33 @@
         "type": "github"
       }
     },
+    "pre-commit": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pre-commit": "pre-commit"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,13 +31,14 @@
 
         mkDevShell = nodejs: pkgs.mkShell {
           nativeBuildInputs = [
+            pkgs.gh
             nodejs
             (pkgs.yarn.override { inherit nodejs; })
           ]
           ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
           shellHook = ''
-            ${pre-commit-check.shellHook}
             export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+            ${pre-commit-check.shellHook}
           '';
         };
       in

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,15 @@
               enable = true;
               name = "pinact";
               description = "Check GitHub Action refs are SHA-pinned and resolvable";
-              entry = "${pkgs.pinact}/bin/pinact run --check";
+              entry = "${pkgs.writeShellScript "pinact-check" ''
+                token="''${GITHUB_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}"
+                if [ -z "$token" ]; then
+                  echo "pinact: skipping — no GITHUB_TOKEN and gh not authenticated" >&2
+                  exit 0
+                fi
+                export GITHUB_TOKEN="$token"
+                exec ${pkgs.pinact}/bin/pinact run --check
+              ''}";
               files = "^\\.github/workflows/.*\\.ya?ml$";
               language = "system";
               pass_filenames = false;

--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,30 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    pre-commit.url = "github:cachix/git-hooks.nix";
+    pre-commit.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, pre-commit }:
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
+
+        pre-commit-check = pre-commit.lib.${system}.run {
+          src = ./.;
+          hooks = {
+            actionlint.enable = true;
+            pinact = {
+              enable = true;
+              name = "pinact";
+              description = "Check GitHub Action refs are SHA-pinned and resolvable";
+              entry = "${pkgs.pinact}/bin/pinact run --check";
+              files = "\\.ya?ml$";
+              language = "system";
+              pass_filenames = false;
+            };
+          };
+          tools = pkgs;
+        };
 
         mkDevShell = nodejs: pkgs.mkShell {
           nativeBuildInputs = [
@@ -16,9 +35,17 @@
             (pkgs.yarn.override { inherit nodejs; })
           ]
           ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
+          shellHook = ''
+            ${pre-commit-check.shellHook}
+            export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+          '';
         };
       in
       {
+        checks = {
+          pre-commit-check = pre-commit-check;
+        };
+
         devShells = {
           default = mkDevShell pkgs.nodejs_22;
           node22  = mkDevShell pkgs.nodejs_22;

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
               name = "pinact";
               description = "Check GitHub Action refs are SHA-pinned and resolvable";
               entry = "${pkgs.pinact}/bin/pinact run --check";
-              files = "\\.ya?ml$";
+              files = "^\\.github/workflows/.*\\.ya?ml$";
               language = "system";
               pass_filenames = false;
             };
@@ -37,7 +37,7 @@
           ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
           shellHook = ''
             ${pre-commit-check.shellHook}
-            export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+            export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
           '';
         };
       in


### PR DESCRIPTION
Pins all remaining action refs to SHAs and adds actionlint + pinact pre-commit hooks via the flake. Note: run after WIF migration PR merges so pinact --check passes on hopr-workflows refs.