### PR TITLE
fix(nix): add Dependabot for nix flake.lock updates, disable Renovate nix manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Renovate's nix manager cannot update flake.lock on Mend-hosted infrastructure:
+  # it requires running `nix flake update` (to compute narHash values), but the
+  # sandboxed jr-microvm environment has no nix binary and allowedCommands is locked
+  # to git add/reset/pwd only. Every Monday run ends with "Digest is not updated" →
+  # level-40 "Error updating branch: update failure". Dependabot handles flake.lock
+  # instead; the nix manager is disabled in renovate.json.
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+      timezone: "UTC"
+    groups:
+      nix-flake-inputs:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,14 @@ updates:
   # to git add/reset/pwd only. Every Monday run ends with "Digest is not updated" →
   # level-40 "Error updating branch: update failure". Dependabot handles flake.lock
   # instead; the nix manager is disabled in renovate.json.
-  - package-ecosystem: "nix"
-    directory: "/"
+  - package-ecosystem: 'nix'
+    directory: '/'
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "02:00"
-      timezone: "UTC"
+      interval: 'weekly'
+      day: 'monday'
+      time: '02:00'
+      timezone: 'UTC'
     groups:
       nix-flake-inputs:
         patterns:
-          - "*"
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       day: 'monday'
       time: '02:00'
       timezone: 'UTC'
+    cooldown:
+      default: 7
     groups:
       nix-flake-inputs:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       time: '02:00'
       timezone: 'UTC'
     cooldown:
-      default: 7
+      default-days: 7
     groups:
       nix-flake-inputs:
         patterns:

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,14 @@
               language = "system";
               pass_filenames = false;
             };
+            dependabot-validator = {
+              enable = true;
+              name = "Dependabot config validator";
+              entry = "${pkgs.check-jsonschema}/bin/check-jsonschema --builtin-schema vendor.dependabot";
+              files = "\\.github/dependabot\\.yml$";
+              language = "system";
+              pass_filenames = true;
+            };
           };
           tools = pkgs;
         };


### PR DESCRIPTION
Renovate's `nix` manager cannot update `flake.lock` on Mend-hosted infrastructure — the sandboxed runner has no `nix` binary and `allowedCommands` is restricted to `git add/reset/pwd`, causing a level-40 "Digest is not updated" error every Monday. Switches to Dependabot's native nix ecosystem support (2026-04-07), which monitors `flake.lock` weekly and groups all inputs into a single PR via `nix-flake-inputs`; disables the Renovate nix manager; adds a `dependabot-validator` pre-commit hook (`check-jsonschema` ≥ 0.37.2 from nixpkgs 26.05); and sets a 7-day cooldown to satisfy the zizmor `insufficient-cooldown` audit.